### PR TITLE
fix: Use feature table to support non-linux-64 platforms

### DIFF
--- a/episodes/code/cuda-example/pixi.toml
+++ b/episodes/code/cuda-example/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["conda-forge"]
 name = "cuda-example"
-platforms = ["linux-64"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 
 [system-requirements]
@@ -11,5 +11,7 @@ cuda = "12"
 
 [dependencies]
 cuda-version = "12.9.*"
+
+[target.linux-64.dependencies]
 cuda = ">=12.9.1,<13"
 pytorch-gpu = ">=2.7.0,<3"


### PR DESCRIPTION
* Add an alert that to solve CUDA environments on non-linux-64 platforms the feature table can be used.
* Note redundancy of cuda package in example.
* Update cuda-example Pixi workspace to support multiple platforms and use the feature table.