### PR TITLE
feat: Add platform based tabs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,9 +69,10 @@ contact: 'matthew.feickert@cern.ch'
 episodes:
 - introduction.md
 - pixi_intro.md
+- backwards_compatibility.md
+- conda_pacakges.md
 - cuda_conda_pacakges.md
 - pixi_deployment.md
-- backwards_compatibility.md
 
 # Information for Learners
 learners:

--- a/episodes/backwards_compatibility.md
+++ b/episodes/backwards_compatibility.md
@@ -52,8 +52,8 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- python >=3.13.3,<3.14
-- numpy >=2.2.6,<3
+- python >=3.13.5,<3.14
+- numpy >=2.3.0,<3
 - notebook >=7.4.3,<8
 - jupyterlab >=4.4.3,<5
 ```

--- a/episodes/conda_pacakges.md
+++ b/episodes/conda_pacakges.md
@@ -1,0 +1,618 @@
+---
+title: "Conda packages"
+teaching: 30
+exercises: 15
+---
+
+::: questions
+
+* What is a conda package?
+
+:::
+
+::: objectives
+
+* Learn about conda package structure
+
+:::
+
+## Conda packages
+
+In a previous episode we learned that Pixi can control conda packages, but what _is_ a conda package?
+[Conda packages](https://docs.conda.io/projects/conda/en/stable/user-guide/concepts/packages.html) (`.conda` files) are language agnostic file archives that contain built code distributions.
+This is quite powerful, as it allows for arbitrary code to be built for any target platform and then packaged with its metadata.
+When a conda package is downloaded and then unpacked with a conda package management tool (e.g. Pixi, conda, mamba) the only thing that needs to be done to "install" that package is just copy the package's file directory tree to the base of the environment's directory tree.
+Package contents are also simple; they can only contain files and symbolic links.
+
+### Exploring package structure
+
+To better understand conda packages and the environment directory tree structure they exist in, let's make a new Pixi project and look at the project environment directory tree structure.
+
+```bash
+pixi init ~/pixi-lesson/dir-structure
+cd ~/pixi-lesson/dir-structure
+```
+```output
+✔ Created /home/<username>/pixi-lesson/dir-structure/pixi.toml
+```
+
+To help visualize this on the command line we'll use the `tree` program (Linux and macOS), which we'll install as a global utility from conda-forge using [`pixi global`](https://pixi.sh/latest/global_tools/introduction/).
+
+::: group-tab
+
+### Unix and Windows Terminal
+
+```bash
+pixi global install tree
+```
+```output
+└── tree: 2.2.1 (installed)
+    └─ exposes: tree
+```
+
+### Windows PowerShell
+
+Windows [PowerShell already has a `tree`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/tree) command, but is less powerful and configurable than the Unix `tree`.
+It provides no way to limit the tree depth, so we'll use other commands instead like
+
+```powershell
+ls -d <depth>
+```
+
+:::
+
+At the moment our Pixi project manifest is empty
+
+```toml
+[workspace]
+channels = ["conda-forge"]
+name = "dir-structure"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+```
+
+and so is our directory tree
+
+::: group-tab
+
+### Unix and Windows Terminal
+
+```bash
+ls -1ap
+```
+```output
+./
+../
+.gitattributes
+.gitignore
+pixi.toml
+```
+
+### Windows PowerShell
+
+```powershell
+ls | fw -col 1
+```
+```output
+.gitattributes
+.gitignore
+pixi.toml
+```
+
+:::
+
+Let's add a dependency to our project to change that
+
+```bash
+pixi add python
+```
+```output
+✔ Added python >=3.13.3,<3.14
+```
+
+which now gives us an update Pixi manifest
+
+```toml
+[workspace]
+channels = ["conda-forge"]
+name = "dir-structure"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+python = ">=3.13.3,<3.14"
+```
+
+and the start of a directory tree with the `.pixi/` directory
+
+::: group-tab
+
+### Unix and Windows Terminal
+
+```bash
+ls -1ap
+```
+```output
+./
+../
+.gitattributes
+.gitignore
+.pixi/
+pixi.lock
+pixi.toml
+```
+
+### Windows PowerShell
+
+```powershell
+ls | fw -col 1
+```
+```output
+.gitattributes
+.gitignore
+.pixi
+pixi.lock
+pixi.toml
+```
+
+:::
+
+Let's now use `tree` to look at the directory structure of the Pixi project starting at the same directory where the `pixi.toml` manifest file is.
+
+::: group-tab
+
+### Unix and Windows Terminal
+
+```bash
+tree -L 3 .pixi/
+```
+```output
+.pixi/
+└── envs
+    └── default
+        ├── bin
+        ├── conda-meta
+        ├── include
+        ├── lib
+        ├── man
+        ├── share
+        ├── ssl
+        ├── x86_64-conda_cos6-linux-gnu
+        └── x86_64-conda-linux-gnu
+
+11 directories, 0 files
+```
+
+### Windows PowerShell
+
+```powershell
+ls -d 3 .pixi\
+```
+```output
+...
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+d----           6/15/2025  7:34 AM                conda-meta
+d----           6/15/2025  7:34 AM                DLLs
+d----           6/15/2025  7:34 AM                etc
+d----           6/15/2025  7:34 AM                include
+d----           6/15/2025  7:34 AM                Lib
+d----           6/15/2025  7:34 AM                Library
+d----           6/15/2025  7:34 AM                libs
+d----           6/15/2025  7:34 AM                Scripts
+d----           6/15/2025  7:34 AM                share
+d----           6/15/2025  7:34 AM                Tools
+...
+```
+
+:::
+
+We see that the `default` environment that Pixi created has the standard directory tree layout for operating systems following the [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/fhs.shtml) (FHS) (e.g. Unix machines)
+
+* `bin`: for binary executables
+* `include`: for include files (e.g. header files in C/C++)
+* `lib`: for binary libraries
+* `share`: for files and data that other libraries or applications might need from the installed programs
+
+as well as some less common ones related to system administration
+
+* `man:` for manual pages
+* `sbin`: for system binaries
+* `ssl`: for SSL (Secure Sockets Layer) certificates to provide secure encryption when connecting to websites
+
+as well as other directories that are specific to conda packages
+
+* `conda-meta`: for metadata for all installed conda packages
+* `x86_64-conda_cos6-linux-gnu` and `x86_64-conda-linux-gnu`: for platform specific tools (like linkers) &mdash; this will vary depending on your operating system
+
+How did this directory tree get here?
+It is a result of all the files that were in the conda packages we downloaded and installed as dependencies of Python.
+
+::: tab
+
+### Linux
+
+```bash
+pixi list
+```
+```output
+Package           Version    Build               Size       Kind   Source
+_libgcc_mutex     0.1        conda_forge         2.5 KiB    conda  https://conda.anaconda.org/conda-forge/
+_openmp_mutex     4.5        2_gnu               23.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+bzip2             1.0.8      h4bc722e_7          246.9 KiB  conda  https://conda.anaconda.org/conda-forge/
+ca-certificates   2025.4.26  hbd8a1cb_0          148.7 KiB  conda  https://conda.anaconda.org/conda-forge/
+ld_impl_linux-64  2.43       h1423503_5          654.9 KiB  conda  https://conda.anaconda.org/conda-forge/
+libexpat          2.7.0      h5888daf_0          72.7 KiB   conda  https://conda.anaconda.org/conda-forge/
+libffi            3.4.6      h2dba641_1          56.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+libgcc            15.1.0     h767d61c_2          809.7 KiB  conda  https://conda.anaconda.org/conda-forge/
+libgcc-ng         15.1.0     h69a702a_2          33.8 KiB   conda  https://conda.anaconda.org/conda-forge/
+libgomp           15.1.0     h767d61c_2          442 KiB    conda  https://conda.anaconda.org/conda-forge/
+liblzma           5.8.1      hb9d3cd8_2          110.2 KiB  conda  https://conda.anaconda.org/conda-forge/
+libmpdec          4.0.0      hb9d3cd8_0          89 KiB     conda  https://conda.anaconda.org/conda-forge/
+libsqlite         3.50.1     hee588c1_0          898.3 KiB  conda  https://conda.anaconda.org/conda-forge/
+libuuid           2.38.1     h0b41bf4_0          32.8 KiB   conda  https://conda.anaconda.org/conda-forge/
+libzlib           1.3.1      hb9d3cd8_2          59.5 KiB   conda  https://conda.anaconda.org/conda-forge/
+ncurses           6.5        h2d0b736_3          870.7 KiB  conda  https://conda.anaconda.org/conda-forge/
+openssl           3.5.0      h7b32b05_1          3 MiB      conda  https://conda.anaconda.org/conda-forge/
+python            3.13.5     hf636f53_101_cp313  31.7 MiB   conda  https://conda.anaconda.org/conda-forge/
+python_abi        3.13       7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
+readline          8.2        h8c095d6_2          275.9 KiB  conda  https://conda.anaconda.org/conda-forge/
+tk                8.6.13     noxft_hd72426e_102  3.1 MiB    conda  https://conda.anaconda.org/conda-forge/
+tzdata            2025b      h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+```
+
+### macOS
+
+```bash
+pixi list
+```
+```output
+Package          Version    Build               Size       Kind   Source
+bzip2            1.0.8      h99b78c6_7          120 KiB    conda  https://conda.anaconda.org/conda-forge/
+ca-certificates  2025.6.15  hbd8a1cb_0          147.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+libexpat         2.7.0      h286801f_0          64.2 KiB   conda  https://conda.anaconda.org/conda-forge/
+libffi           3.4.6      h1da3d7d_1          38.9 KiB   conda  https://conda.anaconda.org/conda-forge/
+liblzma          5.8.1      h39f12f2_2          90.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+libmpdec         4.0.0      h5505292_0          70.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+libsqlite        3.50.1     h3f77e49_0          880.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+libzlib          1.3.1      h8359307_2          45.3 KiB   conda  https://conda.anaconda.org/conda-forge/
+ncurses          6.5        h5e97a16_3          778.3 KiB  conda  https://conda.anaconda.org/conda-forge/
+openssl          3.5.0      h81ee809_1          2.9 MiB    conda  https://conda.anaconda.org/conda-forge/
+python           3.13.5     h81fe080_101_cp313  12.3 MiB   conda  https://conda.anaconda.org/conda-forge/
+python_abi       3.13       7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
+readline         8.2        h1d1bf99_2          246.4 KiB  conda  https://conda.anaconda.org/conda-forge/
+tk               8.6.13     h892fb3f_2          3 MiB      conda  https://conda.anaconda.org/conda-forge/
+tzdata           2025b      h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+```
+
+### Windows
+
+```bash
+pixi list
+```
+```output
+Package          Version       Build               Size       Kind   Source
+bzip2            1.0.8         h2466b09_7          53.6 KiB   conda  https://conda.anaconda.org/conda-forge/
+ca-certificates  2025.4.26     h4c7d964_0          149.4 KiB  conda  https://conda.anaconda.org/conda-forge/
+libexpat         2.7.0         he0c23c2_0          137.6 KiB  conda  https://conda.anaconda.org/conda-forge/
+libffi           3.4.6         h537db12_1          43.9 KiB   conda  https://conda.anaconda.org/conda-forge/
+liblzma          5.8.1         h2466b09_2          102.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+libmpdec         4.0.0         h2466b09_0          86.6 KiB   conda  https://conda.anaconda.org/conda-forge/
+libsqlite        3.50.1        h67fdade_0          1 MiB      conda  https://conda.anaconda.org/conda-forge/
+libzlib          1.3.1         h2466b09_2          54.2 KiB   conda  https://conda.anaconda.org/conda-forge/
+openssl          3.5.0         ha4e3fda_1          8.6 MiB    conda  https://conda.anaconda.org/conda-forge/
+python           3.13.5        h261c0b1_101_cp313  16.1 MiB   conda  https://conda.anaconda.org/conda-forge/
+python_abi       3.13          7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
+tk               8.6.13        h2c6b04d_2          3.3 MiB    conda  https://conda.anaconda.org/conda-forge/
+tzdata           2025b         h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+ucrt             10.0.22621.0  h57928b3_1          546.6 KiB  conda  https://conda.anaconda.org/conda-forge/
+vc               14.3          h2b53caa_26         17.5 KiB   conda  https://conda.anaconda.org/conda-forge/
+vc14_runtime     14.42.34438   hfd919c2_26         733.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+```
+:::
+
+We can download an individual conda package manually using a tool like `curl`.
+Let's download the particular [`python` conda package](https://anaconda.org/conda-forge/python) from where it is hosted on [conda-forge's Anaconda.org organization](https://anaconda.org/conda-forge)
+
+<!-- Can't use group-tab as broken by https://github.com/carpentries/sandpaper/issues/656 -->
+::: tab
+
+### Linux
+
+```bash
+curl -sLO https://anaconda.org/conda-forge/python/3.13.3/download/linux-64/python-3.13.3-hf636f53_101_cp313.conda
+ls *.conda
+```
+```output
+python-3.13.3-hf636f53_101_cp313.conda
+```
+
+### macOS
+
+```bash
+curl -sLO https://anaconda.org/conda-forge/python/3.13.3/download/osx-arm64/python-3.13.3-h81fe080_101_cp313.conda
+ls *.conda
+```
+```output
+python-3.13.3-h81fe080_101_cp313.conda
+```
+
+### Windows
+
+```powershell
+iwr -Uri "https://anaconda.org/conda-forge/python/3.13.3/download/win-64/python-3.13.3-h261c0b1_101_cp313.conda" -OutFile "python-3.13.3-h261c0b1_101_cp313.conda"
+ls *.conda
+```
+```output
+python-3.13.3-h261c0b1_101_cp313.conda
+```
+:::
+
+`.conda` is probably not a file extension that you've seen before, but you are probably very familiar with the actual archive compression format.
+`.conda` files are `.zip` files that have been renamed, but we can use the same utilities to interact with them as we would with `.zip` files.
+
+::: tab
+
+### Linux
+
+```bash
+unzip python-3.13.3-hf636f53_101_cp313.conda -d output
+```
+```output
+Archive:  python-3.13.3-hf636f53_101_cp313.conda
+ extracting: output/metadata.json
+ extracting: output/pkg-python-3.13.3-hf636f53_101_cp313.tar.zst
+ extracting: output/info-python-3.13.3-hf636f53_101_cp313.tar.zst
+```
+
+### macOS
+
+```bash
+unzip python-3.13.3-h81fe080_101_cp313.conda -d output
+```
+```output
+Archive:  python-3.13.3-h81fe080_101_cp313.conda
+ extracting: output/metadata.json
+ extracting: output/pkg-python-3.13.3-h81fe080_101_cp313.tar.zst
+ extracting: output/info-python-3.13.3-h81fe080_101_cp313.tar.zst
+```
+
+### Windows
+
+```powershell
+Expand-Archive "python-3.13.3-h261c0b1_101_cp313.conda" "output"
+```
+```output
+Mode                 LastWriteTime         Length Name
+----                 -------------         ------ ----
+d----           6/15/2025  4:57 PM                pkg
+d----           6/15/2025  4:57 PM                pkg
+-a---            1/1/1980 12:00 AM         133799 info-python-3.13.3-h261c0b1_101_cp313.tar.zst
+-a---           4/14/2025  8:38 PM             31 metadata.json
+-a---            1/1/1980 12:00 AM       16480111 pkg-python-3.13.3-h261c0b1_101_cp313.tar.zst
+```
+:::
+
+We see that the `.conda` archive contained package format metadata (`metadata.json`) as well as two other tar archives compressed with the Zstandard compression algorithm (`.tar.zst`).
+We can uncompress them manually with `tar`
+
+```bash
+cd output
+mkdir -p pkg
+tar --zstd -xvf pkg-python-*.tar.zst --directory pkg
+```
+
+and then look at the uncompressed directory tree with `tree`
+
+::: tab
+
+### Linux
+
+```bash
+tree -L 2 pkg
+```
+```output
+pkg
+├── bin
+│   ├── idle3 -> idle3.13
+│   ├── idle3.13
+│   ├── pydoc -> pydoc3.13
+│   ├── pydoc3 -> pydoc3.13
+│   ├── pydoc3.13
+│   ├── python -> python3.13
+│   ├── python3 -> python3.13
+│   ├── python3.1 -> python3.13
+│   ├── python3.13
+│   ├── python3.13-config
+│   └── python3-config -> python3.13-config
+├── include
+│   └── python3.13
+├── info
+│   └── licenses
+├── lib
+│   ├── libpython3.13.so -> libpython3.13.so.1.0
+│   ├── libpython3.13.so.1.0
+│   ├── libpython3.so
+│   ├── pkgconfig
+│   └── python3.13
+└── share
+    ├── man
+    └── python_compiler_compat
+```
+
+### macOS
+
+```bash
+tree -L 2 pkg
+```
+```output
+pkg
+├── bin
+│   ├── idle3 -> idle3.13
+│   ├── idle3.13
+│   ├── pydoc -> pydoc3.13
+│   ├── pydoc3 -> pydoc3.13
+│   ├── pydoc3.13
+│   ├── python -> python3.13
+│   ├── python3 -> python3.13
+│   ├── python3-config -> python3.13-config
+│   ├── python3.1 -> python3.13
+│   ├── python3.13
+│   └── python3.13-config
+├── include
+│   └── python3.13
+├── info
+│   └── licenses
+├── lib
+│   ├── libpython3.13.dylib
+│   ├── pkgconfig
+│   └── python3.13
+└── share
+    └── man
+```
+
+### Windows
+
+```powershell
+ls -d 2 pkg\
+```
+
+:::
+
+So we can see that the directory structure of the conda package
+
+::: tab
+
+### Linux
+
+```bash
+ls -1p pkg/lib/
+```
+```output
+libpython3.13.so
+libpython3.13.so.1.0
+libpython3.so
+pkgconfig/
+python3.13/
+```
+
+### macOS
+
+```bash
+ls -1p pkg/lib/
+```
+```output
+libpython3.13.dylib
+pkgconfig/
+python3.13/
+```
+
+### Windows
+
+```powershell
+ls pkg | fw -col 1
+```
+```output
+DLLs
+include
+info
+Lib
+libs
+Scripts
+Tools
+LICENSE_PYTHON.txt
+python.exe
+python.pdb
+python3.dll
+python313.dll
+python313.pdb
+pythonw.exe
+pythonw.pdb
+```
+
+:::
+
+is reflected in the directory tree of the Pixi environment with the package installed
+
+::: tab
+
+### Linux
+
+```bash
+cd ..
+ls -1a .pixi/envs/default/lib/libpython*
+```
+```output
+.pixi/envs/default/lib/libpython3.13.so
+.pixi/envs/default/lib/libpython3.13.so.1.0
+.pixi/envs/default/lib/libpython3.so
+```
+
+### macOS
+
+```bash
+cd ..
+ls -1a .pixi/envs/default/lib/libpython*
+```
+```output
+.pixi/envs/default/lib/libpython3.13.dylib
+```
+
+### Windows
+
+```powershell
+cd ..
+ls .pixi\envs\default\python*.dll | fw -col 1
+```
+```output
+python3.dll
+python313.dll
+```
+
+:::
+
+::: discussion
+
+Hopefully this seems straightforward and unmagical &mdash; because it is!
+Conda package structure is simple and easy to understand because it builds off of basic file system structures and doesn't try to invent new systems.
+It is important to demystify what is happening with the directory tree structure though so that we keep in our minds that our tools are just manipulating files.
+
+:::
+
+::: challenge
+
+## Exploring conda-forge
+
+As of 2025 [conda-forge](https://conda-forge.org/) has over 28,500 packages on it.
+Go to the conda-forge package list website (https://conda-forge.org/packages/) and try to find three packages that you use in your research, and three packages from your scientific field that are more niche.
+
+::: solution
+
+## Some packages
+
+Research packages:
+
+* [`jax`](https://github.com/conda-forge/jax-feedstock)
+* [`boost-histogram`](https://github.com/conda-forge/boost-histogram-feedstock)
+* [`awkward`](https://github.com/conda-forge/awkward-feedstock)
+
+Niche particle physics packages:
+
+* [`siscone`](https://github.com/conda-forge/siscone-feedstock)
+* [`iminuit`](https://github.com/conda-forge/iminuit-feedstock)
+* [`stanhf`](https://github.com/conda-forge/stanhf-feedstock)
+
+:::
+:::
+
+::: keypoints
+
+* Conda packages are specially named `.zip` files that contain files and symbolic links structured in a directory tree.
+
+:::

--- a/episodes/cuda_conda_pacakges.md
+++ b/episodes/cuda_conda_pacakges.md
@@ -1,12 +1,11 @@
 ---
-title: "Conda packages and CUDA"
+title: "CUDA conda packages"
 teaching: 30
 exercises: 15
 ---
 
 ::: questions
 
-* What is a conda package?
 * What is CUDA?
 * How can I use CUDA enabled conda packages?
 
@@ -14,317 +13,9 @@ exercises: 15
 
 ::: objectives
 
-* Learn about conda package structure
 * Understand how CUDA can be used with conda packages
 * Create a hardware accelerated environment
 
-:::
-
-## Conda packages
-
-In the last episode we learned that Pixi can control conda packages, but what _is_ a conda package?
-[Conda packages](https://docs.conda.io/projects/conda/en/stable/user-guide/concepts/packages.html) (`.conda` files) are language agnostic file archives that contain built code distributions.
-This is quite powerful, as it allows for arbitrary code to be built for any target platform and then packaged with its metadata.
-When a conda package is downloaded and then unpacked with a conda package management tool (e.g. Pixi, conda, mamba) the only thing that needs to be done to "install" that package is just copy the package's file directory tree to the base of the environment's directory tree.
-Package contents are also simple; they can only contain files and symbolic links.
-
-### Exploring package structure
-
-To better understand conda packages and the environment directory tree structure they exist in, let's make a new Pixi project and look at the project environment directory tree structure.
-
-```bash
-pixi init ~/pixi-lesson/dir-structure
-cd ~/pixi-lesson/dir-structure
-```
-```output
-✔ Created /home/<username>/pixi-lesson/dir-structure/pixi.toml
-```
-
-To help visualize this on the command line we'll use the `tree` program (Linux and macOS), which we'll install as a global utility from conda-forge using [`pixi global`](https://pixi.sh/latest/global_tools/introduction/).
-
-```bash
-pixi global install tree
-```
-```output
-└── tree: 2.2.1 (installed)
-    └─ exposes: tree
-```
-
-Pixi has now installed `tree` for us in a custom environment under `~/.pixi/envs/tree/` and then exposed the `tree` command globally by placing `tree` on our shell's `PATH` at `~/.pixi/bin/tree`.
-This now means that for any new terminal shell we open, `tree` will be available to use.
-
-At the moment our Pixi project manifest is empty
-
-```toml
-[workspace]
-channels = ["conda-forge"]
-name = "dir-structure"
-platforms = ["linux-64"]
-version = "0.1.0"
-
-[tasks]
-
-[dependencies]
-```
-
-and so is our directory tree
-
-```bash
-ls -1ap
-```
-```output
-./
-../
-.gitattributes
-.gitignore
-pixi.toml
-```
-
-Let's add a dependency to our project to change that
-
-```bash
-pixi add python
-```
-```output
-✔ Added python >=3.13.3,<3.14
-```
-
-which now gives us an update Pixi manifest
-
-```toml
-[workspace]
-channels = ["conda-forge"]
-name = "dir-structure"
-platforms = ["linux-64"]
-version = "0.1.0"
-
-[tasks]
-
-[dependencies]
-python = ">=3.13.3,<3.14"
-```
-
-and the start of a directory tree with the `.pixi/` directory
-
-```bash
-ls -1ap
-```
-```output
-./
-../
-.gitattributes
-.gitignore
-.pixi/
-pixi.lock
-pixi.toml
-```
-
-Let's now use `tree` to look at the directory structure of the Pixi project starting at the same directory where the `pixi.toml` manifest file is.
-
-```bash
-tree -L 3 .pixi/
-```
-```output
-.pixi/
-└── envs
-    └── default
-        ├── bin
-        ├── conda-meta
-        ├── include
-        ├── lib
-        ├── man
-        ├── share
-        ├── ssl
-        ├── x86_64-conda_cos6-linux-gnu
-        └── x86_64-conda-linux-gnu
-
-11 directories, 0 files
-```
-
-We see that the `default` environment that Pixi created has the standard directory tree layout for operating systems following the [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/fhs.shtml) (FHS) (e.g. Unix machines)
-
-* `bin`: for binary executables
-* `include`: for include files (e.g. header files in C/C++)
-* `lib`: for binary libraries
-* `share`: for files and data that other libraries or applications might need from the installed programs
-
-as well as some less common ones related to system administration
-
-* `man:` for manual pages
-* `sbin`: for system binaries
-* `ssl`: for SSL (Secure Sockets Layer) certificates to provide secure encryption when connecting to websites
-
-as well as other directories that are specific to conda packages
-
-* `conda-meta`: for metadata for all installed conda packages
-* `x86_64-conda_cos6-linux-gnu` and `x86_64-conda-linux-gnu`: for platform specific tools (like linkers) &mdash; this will vary depending on your operating system
-
-How did this directory tree get here?
-It is a result of all the files that were in the conda packages we downloaded and installed as dependencies of Python.
-
-```bash
-pixi list
-```
-```output
-Package           Version    Build               Size       Kind   Source
-_libgcc_mutex     0.1        conda_forge         2.5 KiB    conda  https://conda.anaconda.org/conda-forge/
-_openmp_mutex     4.5        2_gnu               23.1 KiB   conda  https://conda.anaconda.org/conda-forge/
-bzip2             1.0.8      h4bc722e_7          246.9 KiB  conda  https://conda.anaconda.org/conda-forge/
-ca-certificates   2025.4.26  hbd8a1cb_0          148.7 KiB  conda  https://conda.anaconda.org/conda-forge/
-ld_impl_linux-64  2.43       h712a8e2_4          655.5 KiB  conda  https://conda.anaconda.org/conda-forge/
-libexpat          2.7.0      h5888daf_0          72.7 KiB   conda  https://conda.anaconda.org/conda-forge/
-libffi            3.4.6      h2dba641_1          56.1 KiB   conda  https://conda.anaconda.org/conda-forge/
-libgcc            15.1.0     h767d61c_2          809.7 KiB  conda  https://conda.anaconda.org/conda-forge/
-libgcc-ng         15.1.0     h69a702a_2          33.8 KiB   conda  https://conda.anaconda.org/conda-forge/
-libgomp           15.1.0     h767d61c_2          442 KiB    conda  https://conda.anaconda.org/conda-forge/
-liblzma           5.8.1      hb9d3cd8_2          110.2 KiB  conda  https://conda.anaconda.org/conda-forge/
-libmpdec          4.0.0      hb9d3cd8_0          89 KiB     conda  https://conda.anaconda.org/conda-forge/
-libsqlite         3.50.1     hee588c1_0          898.3 KiB  conda  https://conda.anaconda.org/conda-forge/
-libuuid           2.38.1     h0b41bf4_0          32.8 KiB   conda  https://conda.anaconda.org/conda-forge/
-libzlib           1.3.1      hb9d3cd8_2          59.5 KiB   conda  https://conda.anaconda.org/conda-forge/
-ncurses           6.5        h2d0b736_3          870.7 KiB  conda  https://conda.anaconda.org/conda-forge/
-openssl           3.5.0      h7b32b05_1          3 MiB      conda  https://conda.anaconda.org/conda-forge/
-python            3.13.3     hf636f53_101_cp313  31.7 MiB   conda  https://conda.anaconda.org/conda-forge/
-python_abi        3.13       7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
-readline          8.2        h8c095d6_2          275.9 KiB  conda  https://conda.anaconda.org/conda-forge/
-tk                8.6.13     noxft_hd72426e_102  3.1 MiB    conda  https://conda.anaconda.org/conda-forge/
-tzdata            2025b      h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
-```
-
-We can download an individual conda package manually using `curl`.
-Let's ensure you have `curl` first
-
-```bash
-pixi global install curl
-```
-```output
-└── curl: 8.14.1 (installed)
-    └─ exposes: curl
-```
-
-and then use it to download the particular [`python` conda package](https://anaconda.org/conda-forge/python) from where it is hosted on [conda-forge's Anaconda.org organization](https://anaconda.org/conda-forge)
-
-```bash
-curl -sLO https://anaconda.org/conda-forge/python/3.13.3/download/linux-64/python-3.13.3-hf636f53_101_cp313.conda
-ls *.conda
-```
-```output
-python-3.13.3-hf636f53_101_cp313.conda
-```
-
-`.conda` is probably not a file extension that you've seen before, but you are probably very familiar with the actual archive compression format.
-`.conda` files are `.zip` files that have been renamed, but we can use the same utilities to interact with them as we would with `.zip` files.
-
-```bash
-unzip python-3.13.3-hf636f53_101_cp313.conda -d output
-```
-```output
-Archive:  python-3.13.3-hf636f53_101_cp313.conda
- extracting: output/metadata.json
- extracting: output/pkg-python-3.13.3-hf636f53_101_cp313.tar.zst
- extracting: output/info-python-3.13.3-hf636f53_101_cp313.tar.zst
-```
-
-We see that the `.conda` archive contained package format metadata (`metadata.json`) as well as two other tar archives compressed with the Zstandard compression algorithm (`.tar.zst`).
-We can uncompress them manually with `tar`
-
-```bash
-cd output
-mkdir -p pkg
-tar --zstd -xvf pkg-python-3.13.3-hf636f53_101_cp313.tar.zst --directory pkg
-```
-
-and then look at the uncompressed directory tree with `tree`
-
-```bash
-tree -L 2 pkg
-```
-```output
-pkg
-├── bin
-│   ├── idle3 -> idle3.13
-│   ├── idle3.13
-│   ├── pydoc -> pydoc3.13
-│   ├── pydoc3 -> pydoc3.13
-│   ├── pydoc3.13
-│   ├── python -> python3.13
-│   ├── python3 -> python3.13
-│   ├── python3.1 -> python3.13
-│   ├── python3.13
-│   ├── python3.13-config
-│   └── python3-config -> python3.13-config
-├── include
-│   └── python3.13
-├── info
-│   └── licenses
-├── lib
-│   ├── libpython3.13.so -> libpython3.13.so.1.0
-│   ├── libpython3.13.so.1.0
-│   ├── libpython3.so
-│   ├── pkgconfig
-│   └── python3.13
-└── share
-    ├── man
-    └── python_compiler_compat
-```
-
-So we can see that the directory structure of the conda package
-
-```bash
-ls -1p pkg/lib/
-```
-```output
-libpython3.13.so
-libpython3.13.so.1.0
-libpython3.so
-pkgconfig/
-python3.13/
-```
-
-is reflected in the directory tree of the Pixi environment with the package installed
-
-```bash
-cd ..
-ls -1a .pixi/envs/default/lib/libpython*
-```
-```output
-.pixi/envs/default/lib/libpython3.13.so
-.pixi/envs/default/lib/libpython3.13.so.1.0
-.pixi/envs/default/lib/libpython3.so
-```
-
-::: discussion
-
-Hopefully this seems straightforward and unmagical &mdash; because it is!
-Conda package structure is simple and easy to understand because it builds off of basic file system structures and doesn't try to invent new systems.
-It is important to demystify what is happening with the directory tree structure though so that we keep in our minds that our tools are just manipulating files.
-
-:::
-
-::: challenge
-
-## Exploring conda-forge
-
-As of 2025 [conda-forge](https://conda-forge.org/) has over 28,500 packages on it.
-Go to the conda-forge package list website (https://conda-forge.org/packages/) and try to find three packages that you use in your research, and three packages from your scientific field that are more niche.
-
-::: solution
-
-## Some packages
-
-Research packages:
-
-* [`jax`](https://github.com/conda-forge/jax-feedstock)
-* [`boost-histogram`](https://github.com/conda-forge/boost-histogram-feedstock)
-* [`awkward`](https://github.com/conda-forge/awkward-feedstock)
-
-Niche particle physics packages:
-
-* [`siscone`](https://github.com/conda-forge/siscone-feedstock)
-* [`iminuit`](https://github.com/conda-forge/iminuit-feedstock)
-* [`stanhf`](https://github.com/conda-forge/stanhf-feedstock)
-
-:::
 :::
 
 ## CUDA
@@ -339,7 +30,7 @@ CUDA then required a [multi-step installation process](https://docs.nvidia.com/c
 This meant that when CUDA enabled environments were setup on a particular machine they were powerful and optimized, but brittle to change and could easily be broken if system wide updates (like for security fixes) occurred.
 CUDA software environments were bespoke and not many scientists understood how to construct and curate them.
 
-### CUDA on conda-forge
+## CUDA on conda-forge
 
 In [late 2018](https://github.com/conda-forge/conda-forge.github.io/issues/687) to better support the scientific developer community, NVIDIA started to release components of the CUDA toolkits on the [`nvidia` conda channel](https://anaconda.org/nvidia).
 This provided the first access to start to create conda environments where the versions of different CUDA tools could be directly specified and downloaded.
@@ -378,7 +69,7 @@ Global
 
 ```
 
-### CUDA use with Pixi
+## CUDA use with Pixi
 
 To be able to effectively use CUDA conda packages with Pixi, we make use of Pixi's [system requirement workspace table](https://pixi.sh/latest/workspace/system_requirements/), which specifies the **minimum**  system specifications needed to install and run a Pixi workspace's environments.
 
@@ -637,7 +328,7 @@ pixi add --platform linux-64 pytorch-gpu
 Added these only for platform(s): linux-64
 ```
 ```bash
- pixi list --platform linux-64 torch
+pixi list --platform linux-64 torch
 ```
 ```output
 Package      Version  Build                           Size       Kind   Source
@@ -965,7 +656,6 @@ we created separate CPU and GPU computational environments that are now fully re
 
 ::: keypoints
 
-* Conda packages are specially named `.zip` files that contain files and symbolic links structured in a directory tree.
 * The `cuda-version` metapackage can be used to specify constrains on the versions of the `__cuda` virtual package and `cudatoolkit`.
 * Pixi can specify a minimum required CUDA version with the `[system-requirements]` table.
 * Pixi can solve environments for platforms that are not the system platform.

--- a/episodes/pixi_intro.md
+++ b/episodes/pixi_intro.md
@@ -90,6 +90,10 @@ Created /home/<username>/pixi-lesson/example/pixi.toml
 
 Navigate to the `example` directory and check the directory structure
 
+:::: group-tab
+
+### Unix and Windows Terminal
+
 ```bash
 cd example
 ls -1ap
@@ -102,6 +106,21 @@ ls -1ap
 .gitignore
 pixi.toml
 ```
+
+### Windows PowerShell
+
+```powershell
+cd example
+ls | fw -col 1
+```
+
+```output
+.gitattributes
+.gitignore
+pixi.toml
+```
+
+::::
 
 We see that Pixi  has setup Git configuration files for the project as well as a Pixi manifest `pixi.toml` file.
 Checking the default manifest file, we see three TOML tables: `workspace`, `tasks`, and `dependencies`.
@@ -167,6 +186,10 @@ python = ">=3.13.3,<3.14"
 
 Further, we also now see that a `pixi.lock` lock file has been created in the project directory as well as a `.pixi/` directory.
 
+:::: group-tab
+
+### Unix and Windows Terminal
+
 ```bash
 ls -1ap
 ```
@@ -181,8 +204,27 @@ pixi.lock
 pixi.toml
 ```
 
+### Windows PowerShell
+
+```powershell
+ls | fw -col 1
+```
+
+```output
+.pixi
+.gitattributes
+.gitignore
+pixi.lock
+pixi.toml
+```
+::::
+
 The `.pixi/` directory contains the installed environments.
 We can see that at the moment there is just one environment named `default`
+
+:::: group-tab
+
+### Unix and Windows Terminal
 
 ```bash
 ls -1p .pixi/envs/
@@ -190,6 +232,16 @@ ls -1p .pixi/envs/
 ```output
 default/
 ```
+
+### Windows PowerShell
+
+```powershell
+ls .pixi\envs | fw -col 1
+```
+```output
+default
+```
+::::
 
 Inside the `.pixi/envs/default/` directory are all the libraries, header files, and executables that are needed by the environment.
 
@@ -212,6 +264,10 @@ pixi clean
 
 We can also see all the packages that were installed and are now available for us to use with [`pixi list`](https://pixi.sh/latest/reference/cli/pixi/list/)
 
+::: tab
+
+### Linux
+
 ```bash
 pixi list
 ```
@@ -221,31 +277,84 @@ _libgcc_mutex     0.1        conda_forge         2.5 KiB    conda  https://conda
 _openmp_mutex     4.5        2_gnu               23.1 KiB   conda  https://conda.anaconda.org/conda-forge/
 bzip2             1.0.8      h4bc722e_7          246.9 KiB  conda  https://conda.anaconda.org/conda-forge/
 ca-certificates   2025.4.26  hbd8a1cb_0          148.7 KiB  conda  https://conda.anaconda.org/conda-forge/
-ld_impl_linux-64  2.43       h712a8e2_4          655.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+ld_impl_linux-64  2.43       h1423503_5          654.9 KiB  conda  https://conda.anaconda.org/conda-forge/
 libexpat          2.7.0      h5888daf_0          72.7 KiB   conda  https://conda.anaconda.org/conda-forge/
 libffi            3.4.6      h2dba641_1          56.1 KiB   conda  https://conda.anaconda.org/conda-forge/
 libgcc            15.1.0     h767d61c_2          809.7 KiB  conda  https://conda.anaconda.org/conda-forge/
 libgcc-ng         15.1.0     h69a702a_2          33.8 KiB   conda  https://conda.anaconda.org/conda-forge/
 libgomp           15.1.0     h767d61c_2          442 KiB    conda  https://conda.anaconda.org/conda-forge/
-liblzma           5.8.1      hb9d3cd8_1          110.2 KiB  conda  https://conda.anaconda.org/conda-forge/
+liblzma           5.8.1      hb9d3cd8_2          110.2 KiB  conda  https://conda.anaconda.org/conda-forge/
 libmpdec          4.0.0      hb9d3cd8_0          89 KiB     conda  https://conda.anaconda.org/conda-forge/
-libsqlite         3.50.0     hee588c1_0          897.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+libsqlite         3.50.1     hee588c1_0          898.3 KiB  conda  https://conda.anaconda.org/conda-forge/
 libuuid           2.38.1     h0b41bf4_0          32.8 KiB   conda  https://conda.anaconda.org/conda-forge/
 libzlib           1.3.1      hb9d3cd8_2          59.5 KiB   conda  https://conda.anaconda.org/conda-forge/
 ncurses           6.5        h2d0b736_3          870.7 KiB  conda  https://conda.anaconda.org/conda-forge/
 openssl           3.5.0      h7b32b05_1          3 MiB      conda  https://conda.anaconda.org/conda-forge/
-python            3.13.3     hf636f53_101_cp313  31.7 MiB   conda  https://conda.anaconda.org/conda-forge/
+python            3.13.5     hf636f53_101_cp313  31.7 MiB   conda  https://conda.anaconda.org/conda-forge/
 python_abi        3.13       7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
 readline          8.2        h8c095d6_2          275.9 KiB  conda  https://conda.anaconda.org/conda-forge/
 tk                8.6.13     noxft_hd72426e_102  3.1 MiB    conda  https://conda.anaconda.org/conda-forge/
 tzdata            2025b      h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
 ```
 
+### macOS
+
+```bash
+pixi list
+```
+```output
+Package          Version    Build               Size       Kind   Source
+bzip2            1.0.8      h99b78c6_7          120 KiB    conda  https://conda.anaconda.org/conda-forge/
+ca-certificates  2025.4.26  hbd8a1cb_0          148.7 KiB  conda  https://conda.anaconda.org/conda-forge/
+libexpat         2.7.0      h286801f_0          64.2 KiB   conda  https://conda.anaconda.org/conda-forge/
+libffi           3.4.6      h1da3d7d_1          38.9 KiB   conda  https://conda.anaconda.org/conda-forge/
+liblzma          5.8.1      h39f12f2_2          90.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+libmpdec         4.0.0      h5505292_0          70.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+libsqlite        3.50.1     h3f77e49_0          880.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+libzlib          1.3.1      h8359307_2          45.3 KiB   conda  https://conda.anaconda.org/conda-forge/
+ncurses          6.5        h5e97a16_3          778.3 KiB  conda  https://conda.anaconda.org/conda-forge/
+openssl          3.5.0      h81ee809_1          2.9 MiB    conda  https://conda.anaconda.org/conda-forge/
+python           3.13.5     h81fe080_101_cp313  12.3 MiB   conda  https://conda.anaconda.org/conda-forge/
+python_abi       3.13       7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
+readline         8.2        h1d1bf99_2          246.4 KiB  conda  https://conda.anaconda.org/conda-forge/
+tk               8.6.13     h892fb3f_2          3 MiB      conda  https://conda.anaconda.org/conda-forge/
+tzdata           2025b      h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+```
+
+### Windows
+
+```bash
+pixi list
+```
+```output
+Package          Version       Build               Size       Kind   Source
+bzip2            1.0.8         h2466b09_7          53.6 KiB   conda  https://conda.anaconda.org/conda-forge/
+ca-certificates  2025.4.26     h4c7d964_0          149.4 KiB  conda  https://conda.anaconda.org/conda-forge/
+libexpat         2.7.0         he0c23c2_0          137.6 KiB  conda  https://conda.anaconda.org/conda-forge/
+libffi           3.4.6         h537db12_1          43.9 KiB   conda  https://conda.anaconda.org/conda-forge/
+liblzma          5.8.1         h2466b09_2          102.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+libmpdec         4.0.0         h2466b09_0          86.6 KiB   conda  https://conda.anaconda.org/conda-forge/
+libsqlite        3.50.1        h67fdade_0          1 MiB      conda  https://conda.anaconda.org/conda-forge/
+libzlib          1.3.1         h2466b09_2          54.2 KiB   conda  https://conda.anaconda.org/conda-forge/
+openssl          3.5.0         ha4e3fda_1          8.6 MiB    conda  https://conda.anaconda.org/conda-forge/
+python           3.13.5        h261c0b1_101_cp313  16.1 MiB   conda  https://conda.anaconda.org/conda-forge/
+python_abi       3.13          7_cp313             6.8 KiB    conda  https://conda.anaconda.org/conda-forge/
+tk               8.6.13        h2c6b04d_2          3.3 MiB    conda  https://conda.anaconda.org/conda-forge/
+tzdata           2025b         h78e105d_0          120.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+ucrt             10.0.22621.0  h57928b3_1          546.6 KiB  conda  https://conda.anaconda.org/conda-forge/
+vc               14.3          h2b53caa_26         17.5 KiB   conda  https://conda.anaconda.org/conda-forge/
+vc14_runtime     14.42.34438   hfd919c2_26         733.1 KiB  conda  https://conda.anaconda.org/conda-forge/
+```
+:::
+
 ::: challenge
 
 ## Extending the manifest
 
 Let's extend this manifest to add the Python library `numpy` and the Jupyter tools `notebook` and `jupyterlab` as dependencies and add a task called `lab` that will launch Jupyter Lab in the current working directory.
+
+Hint: Look at the Pixi manifest table structure to think how a `task` might be added.
+It is fine to read the docs too!
 
 ::: solution
 
@@ -255,9 +364,21 @@ Let's start at the command line and add the additional dependencies with `pixi a
 pixi add numpy notebook jupyterlab
 ```
 
-Then let's manually edit the `pixi.toml` with a text editor to add a task named `lab` that when called executes `jupyter lab`.
+We can manually edit the `pixi.toml` with a text editor to add a task named `lab` that when called executes `jupyter lab`.
+This is sometimes the easiest thing to do, but we can also use the `pixi` CLI.
+
+```bash
+pixi task add lab "jupyter lab" --description "Launch JupyterLab"
+```
+```output
+✔ Added task `lab`: jupyter lab, description = "Launch JupyterLab
+```
 
 The resulting `pixi.toml` manifest is
+
+:::: tab
+
+### Manually edited
 
 ```toml
 [workspace]
@@ -271,12 +392,32 @@ description = "Launch JupyterLab"
 cmd = "jupyter lab"
 
 [dependencies]
-python = ">=3.13.3,<3.14"
-numpy = ">=2.2.6,<3"
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
 notebook = ">=7.4.3,<8"
 jupyterlab = ">=4.4.3,<5"
 ```
 
+### `pixi task` CLI
+
+```toml
+[workspace]
+channels = ["conda-forge"]
+name = "example"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+lab = { cmd = "jupyter lab", description = "Launch JupyterLab" }
+
+[dependencies]
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
+notebook = ">=7.4.3,<8"
+jupyterlab = ">=4.4.3,<5"
+```
+
+::::
 :::
 :::
 
@@ -287,6 +428,91 @@ pixi run lab
 ```
 
 and we see that Jupyter Lab launches!
+
+::: challenge
+
+## Adding the canonical Pixi `start` task
+
+For Pixi projects, it is canonical to have a `start` task so that for any Pixi project a user can run
+
+```bash
+pixi run start
+```
+
+and begin to explore the project.
+Add a task called `start` that depends-on the `lab` task.
+
+::: solution
+
+:::: tab
+
+### Manually edited
+
+```toml
+[workspace]
+channels = ["conda-forge"]
+name = "example"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks.lab]
+description = "Launch JupyterLab"
+cmd = "jupyter lab"
+
+[tasks.start]
+description = "Start exploring the Pixi project"
+depends-on = ["lab"]
+
+[dependencies]
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
+notebook = ">=7.4.3,<8"
+jupyterlab = ">=4.4.3,<5"
+```
+
+### `pixi task` CLI
+
+```toml
+[workspace]
+channels = ["conda-forge"]
+name = "example"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+lab = { cmd = "jupyter lab", description = "Launch JupyterLab" }
+start = { depends-on = [{ task = "lab" }], description = "Start exploring the Pixi project" }
+
+[dependencies]
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
+notebook = ">=7.4.3,<8"
+jupyterlab = ">=4.4.3,<5"
+```
+::::
+
+:::
+:::
+
+::: testimonial
+
+## Task overview
+
+A user can also run `pixi task list` to get a summary of the tasks that are available to them in the workspace.
+
+```bash
+pixi task list
+```
+```output
+Tasks that can run on this machine:
+-----------------------------------
+lab, start
+Task   Description
+lab    Launch JupyterLab
+start  Start exploring the Pixi project
+```
+
+:::
 
 Here we used `pixi run` to execute tasks in the workspace's environments without ever explicitly activating the environment.
 This is a different behavior compared to tools like conda of Python virtual environments, where the assumption is that you have activated an environment before using it.
@@ -303,29 +529,34 @@ You can now directly run commands that use the environment.
 python
 ```
 ```output
-Python 3.13.3 | packaged by conda-forge | (main, Apr 14 2025, 20:44:03) [GCC 13.3.0] on linux
+Python 3.13.5 | packaged by conda-forge | (main, Jun 13 2025, 01:14:40) [GCC 13.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
 
 As we're in a subshell, to exit the environment and move back to the shell that launched the subshell, just `exit` the shell.
 
-```
-bash
+```bash
+exit
 ```
 
 ::: challenge
 
 ## Multi platform projects
 
-Extend your project to additionally support the `linux-64` and `osx-arm64` platforms.
+Extend your project to additionally support the `linux-64`, `osx-arm64`, and `win-64` platforms.
 
 ::: solution
 
 Using the [`pixi workspace` CLI API](https://pixi.sh/latest/reference/cli/pixi/workspace/), one can add the platforms with
 
 ```bash
-pixi workspace platform add linux-64 osx-arm64
+pixi workspace platform add linux-64 osx-arm64 win-64
+```
+```output
+✔ Added linux-64
+✔ Added osx-arm64
+✔ Added win-64
 ```
 
 This both adds the platforms to the `workspace` `platforms` list and solves for the platforms and updates the lock file!
@@ -338,20 +569,23 @@ The resulting `pixi.toml` manifest is
 [workspace]
 channels = ["conda-forge"]
 name = "example"
-platforms = ["linux-64", "osx-arm64"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 
 [tasks.lab]
 description = "Launch JupyterLab"
 cmd = "jupyter lab"
 
+[tasks.start]
+description = "Start exploring the Pixi project"
+depends-on = ["lab"]
+
 [dependencies]
-python = ">=3.13.3,<3.14"
-numpy = ">=2.2.6,<3"
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
 notebook = ">=7.4.3,<8"
 jupyterlab = ">=4.4.3,<5"
 ```
-
 :::
 :::
 
@@ -363,16 +597,20 @@ We can create a new `feature` named `dev` and then create an `environment` also 
 [workspace]
 channels = ["conda-forge"]
 name = "example"
-platforms = ["linux-64", "osx-arm64"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 
 [tasks.lab]
 description = "Launch JupyterLab"
 cmd = "jupyter lab"
 
+[tasks.start]
+description = "Start exploring the Pixi project"
+depends-on = ["lab"]
+
 [dependencies]
-python = ">=3.13.3,<3.14"
-numpy = ">=2.2.6,<3"
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
 notebook = ">=7.4.3,<8"
 jupyterlab = ">=4.4.3,<5"
 
@@ -381,16 +619,6 @@ jupyterlab = ">=4.4.3,<5"
 [environments]
 dev = ["dev"]
 ```
-
-::: callout
-
-The `pixi workspace` CLI can also be used to add existing `featues` to environments
-
-```bash
-pixi workspace environment add --feature dev dev
-```
-
-:::
 
 We can now add `pre-commit` to the `dev` feature's `dependencies` and have it be accessible in the `dev` environment.
 
@@ -406,16 +634,20 @@ Added these only for feature: dev
 [workspace]
 channels = ["conda-forge"]
 name = "example"
-platforms = ["linux-64", "osx-arm64"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 
 [tasks.lab]
 description = "Launch JupyterLab"
 cmd = "jupyter lab"
 
+[tasks.start]
+description = "Start exploring the Pixi project"
+depends-on = ["lab"]
+
 [dependencies]
-python = ">=3.13.3,<3.14"
-numpy = ">=2.2.6,<3"
+python = ">=3.13.5,<3.14"
+numpy = ">=2.3.0,<3"
 notebook = ">=7.4.3,<8"
 jupyterlab = ">=4.4.3,<5"
 
@@ -434,6 +666,50 @@ pixi run --environment dev pre-commit --help
 ```bash
 pixi shell --environment dev
 ```
+
+::: caution
+
+The `pixi workspace` CLI can also be used to add existing `featues` to environments, but a feature needs to be defined before it can be added to the manifest
+
+```bash
+pixi add --feature dev pre-commit
+pixi workspace environment add --feature dev dev
+pixi upgrade --feature dev pre-commit
+```
+
+:::
+
+## Global Tools
+
+With the [`pixi global` CLI API](https://pixi.sh/dev/reference/cli/pixi/global/), users can manage globally installed tools in a way that makes them available from any directory on their machine.
+
+As an example, we can install the [`bat`](https://github.com/sharkdp/bat) program &mdash; a `cat` clone with syntax highlighting and Git integration &mdash; as a global utility from conda-forge using [`pixi global`](https://pixi.sh/latest/global_tools/introduction/).
+
+```bash
+pixi global install bat
+```
+```output
+└── bat: 0.25.0 (installed)
+    └─ exposes: bat
+```
+
+Pixi has now installed `bat` for us in a custom environment under `~/.pixi/envs/bat/` and then exposed the `bat` command globally by placing `bat` on our shell's `PATH` at `~/.pixi/bin/bat`.
+This now means that for any new terminal shell we open, `bat` will be available to use.
+
+Using `pixi global` has also created a `~/.pixi/manifests/pixi-global.toml` file that tracks all of the software that is globally installed by Pixi
+
+```toml
+version = 1
+
+[envs.bat]
+channels = ["conda-forge"]
+dependencies = { bat = "*" }
+exposed = { bat = "bat" }
+```
+
+As new software is added to the system with `pixi global` this global manifest is updated.
+If the global manifest is updated manually, the next time `pixi global update` is run, the environments defined in the global manifest will be installed on the system.
+This means that by sharing a Pixi global manifest, a new machine can be provisioned with an entire suite of command line tools in seconds.
 
 ::: keypoints
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -13,8 +13,25 @@ This gives you version controlled examples that you can take forward with you as
 
 1. Create a [GitHub account](https://github.com/) if you don't have one yet.
 1. Navigate to your GitHub profile (https://github.com/<username>) and click the "+" icon in the upper right hand side to [create a new repository](https://github.com/new).
-1. Name the new repository "pixi-lesson", make it public, and give it a README and an [open source license](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) (e.g. MIT License).
+1. Name the new repository named `pixi-lesson`, make it public, and give it a README and an [open source license](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) (e.g. MIT License).
 1. As GitHub requires two-factor authentication, it is highly recommended that you [generate an SSH key pair](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) specifically for GitHub, [add the generated SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account), and then use your SSH keys to connect with GitHub.
+
+::: caution
+
+# What do I do if I don't have Git installed on my machine?
+
+Jump to the next section ("Software Setup") and install Pixi.
+Then, run this command (which we'll cover in the lesson) in your terminal
+
+```bash
+pixi global install git
+```
+
+and you'll have Git installed. :+1:
+
+You can of course install Git in other ways depending on your operating system, but this is straightforward and will work for everyone.
+
+:::
 
 ## Software Setup
 
@@ -39,13 +56,13 @@ macOS users and Windows and Linux users that don't have access to NVIDIA GPUs ca
 
 ### Unix machines (Linux and macOS)
 
-```shell
+```bash
 curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
 or
 
-```shell
+```bash
 wget -qO- https://pixi.sh/install.sh | sh
 ```
 
@@ -72,7 +89,7 @@ eval "$(pixi completion --shell zsh)"
 
 Add the following to the end of `~/.config/fish/config.fish`:
 
-```shell
+```fish
 pixi completion --shell fish | source
 ```
 
@@ -107,3 +124,18 @@ Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`.
 ```
 
 ::::::::::::::::::::::::
+
+## Docker (Optional)
+
+While not explicitly required for this lesson, if you would like to have a more full interactive experience with the material it is suggested that you install the Linux container runtime and tool [Docker](https://www.docker.com/).
+Install instructions for Docker can be found for your specific platform on [the Docker docs website](https://docs.docker.com/desktop/).
+
+::: callout
+
+If you're on Linux and would prefer to use [Apptainer](https://apptainer.org/) &mdash; if you don't know what that is don't worry &mdash; you can install that with
+
+```bash
+pixi global install apptainer
+```
+
+:::


### PR DESCRIPTION
* Add platform specific based tabs to make instruction more clear.
* Split conda pacakges and CUDA into two episodes.
* Move backwards compatability with conda forward in the episode order.
* Add Docker installation as an optional setup step.