### PR TITLE
feat: Add episode on HTC systems

### DIFF
--- a/.github/workflows/lesson-tests.yaml
+++ b/.github/workflows/lesson-tests.yaml
@@ -209,3 +209,34 @@ jobs:
         pixi add --platform linux-64 pytorch-gpu
         pixi list --platform linux-64 torch
         cat pixi.toml
+
+  episode-mnist-example:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.8.8
+      with:
+        run-install: false
+
+    - name: Run Pixi cuda-example episode
+      shell: pixi run bash -ex {0}
+      run: |
+        pixi init mnist-example
+        cd mnist-example
+        pixi workspace platform add linux-64 osx-arm64 win-64
+        pixi add python
+        pixi add --feature cpu pytorch-cpu torchvision
+        pixi workspace environment add --feature cpu cpu
+        pixi upgrade --feature cpu
+        pixi workspace system-requirements add --feature gpu cuda 12
+        export CONDA_OVERRIDE_CUDA=12
+        pixi workspace environment add --feature gpu gpu
+        pixi add --platform linux-64 --feature gpu pytorch-gpu torchvision
+        cat pixi.toml

--- a/.github/workflows/lesson-tests.yaml
+++ b/.github/workflows/lesson-tests.yaml
@@ -240,3 +240,5 @@ jobs:
         pixi workspace environment add --feature gpu gpu
         pixi add --platform linux-64 --feature gpu pytorch-gpu torchvision
         cat pixi.toml
+        pixi list --environment cpu
+        pixi list --environment gpu

--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,7 @@ episodes:
 - conda_pacakges.md
 - cuda_conda_pacakges.md
 - pixi_deployment.md
+- htc_systems.md
 
 # Information for Learners
 learners:

--- a/episodes/code/mnist-example/.github/workflows/ci.yaml
+++ b/episodes/code/mnist-example/.github/workflows/ci.yaml
@@ -1,0 +1,89 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+    paths:
+      - 'htcondor/pixi.toml'
+      - 'htcondor/pixi.lock'
+      - 'htcondor/Dockerfile'
+      - 'htcondor/.dockerignore'
+  pull_request:
+    paths:
+      - 'htcondor/pixi.toml'
+      - 'htcondor/pixi.lock'
+      - 'htcondor/Dockerfile'
+      - 'htcondor/.dockerignore'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  docker:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=hello-pytorch-noble-cuda-12.9
+            type=raw,value=latest
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test build
+        id: docker_build_test
+        uses: docker/build-push-action@v6
+        with:
+          context: htcondor
+          file: htcondor/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          pull: true
+
+      - name: Deploy build
+        id: docker_build_deploy
+        uses: docker/build-push-action@v6
+        with:
+          context: htcondor
+          file: htcondor/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}

--- a/episodes/code/mnist-example/htcondor/.gitattributes
+++ b/episodes/code/mnist-example/htcondor/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/episodes/code/mnist-example/htcondor/.gitignore
+++ b/episodes/code/mnist-example/htcondor/.gitignore
@@ -1,0 +1,4 @@
+
+# pixi environments
+.pixi
+*.egg-info

--- a/episodes/code/mnist-example/htcondor/Dockerfile
+++ b/episodes/code/mnist-example/htcondor/Dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/prefix-dev/pixi:noble AS build
+
+WORKDIR /app
+COPY . .
+ENV CONDA_OVERRIDE_CUDA=12
+RUN pixi install --locked --environment gpu
+RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
+    pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
+    echo 'exec "$@"' >> /app/entrypoint.sh
+
+FROM ghcr.io/prefix-dev/pixi:noble AS production
+
+WORKDIR /app
+COPY --from=build /app/.pixi/envs/gpu /app/.pixi/envs/gpu
+COPY --from=build /app/pixi.toml /app/pixi.toml
+COPY --from=build /app/pixi.lock /app/pixi.lock
+# The ignore files are needed for 'pixi run' to work in the container
+COPY --from=build /app/.pixi/.gitignore /app/.pixi/.gitignore
+COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
+COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
+
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/episodes/code/mnist-example/htcondor/interact.sh
+++ b/episodes/code/mnist-example/htcondor/interact.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Download the training data locally to transfer to the worker node
+if [ ! -f "MNIST_data.tar.gz" ]; then
+    # c.f. https://github.com/CHTC/templates-GPUs/blob/450081144c6ae0657123be2a9a357cb432d9d394/shared/pytorch/MNIST_data.tar.gz
+    curl -sLO https://raw.githubusercontent.com/CHTC/templates-GPUs/450081144c6ae0657123be2a9a357cb432d9d394/shared/pytorch/MNIST_data.tar.gz
+fi
+
+# Ensure existing models are backed up
+if [ -f "mnist_cnn.pt" ]; then
+    mv mnist_cnn.pt mnist_cnn_"$(date '+%Y-%m-%d-%H-%M')".pt.bak
+fi
+
+condor_submit -interactive mnist_gpu_docker.sub

--- a/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sh
+++ b/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# detailed logging to stderr
+set -x
+
+echo -e "# Hello CHTC from Job ${1} running on $(hostname)\n"
+echo -e "# GPUs assigned: ${CUDA_VISIBLE_DEVICES}\n"
+
+echo -e "# Activate Pixi environment\n"
+# The last line of the entrypoint.sh file is 'exec "$@"'. If this shell script
+# receives arguments, exec will interpret them as arguments to it, which is not
+# intended. To avoid this, strip the last line of entrypoint.sh and source that
+# instead.
+. <(sed '$d' /app/entrypoint.sh)
+
+echo -e "# Check to see if the NVIDIA drivers can correctly detect the GPU:\n"
+nvidia-smi
+
+echo -e "\n# Check if PyTorch can detect the GPU:\n"
+python ./src/torch_detect_GPU.py
+
+echo -e "\n# Extract the training data:\n"
+if [ -f "MNIST_data.tar.gz" ]; then
+    tar -vxzf MNIST_data.tar.gz
+else
+    echo "The training data archive, MNIST_data.tar.gz, is not found."
+    echo "Please transfer it to the worker node in the HTCondor jobs submission file."
+    exit 1
+fi
+
+echo -e "\n# Check that the training code exists:\n"
+ls -1ap ./src/
+
+echo -e "\n# Train MNIST with PyTorch:\n"
+time python ./src/torch_MNIST.py --data-dir ./data --epochs 14 --save-model

--- a/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sub
+++ b/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sub
@@ -1,0 +1,46 @@
+# mnist_gpu_docker.sub
+# Submit file to access the GPU via docker
+
+# Set the "universe" to 'container' to use Docker
+universe = container
+# the container images are cached, and so if a container image tag is
+# overwritten it will not be pulled again
+container_image = docker://ghcr.io/<github user name>/pixi-lesson:sha-<sha>
+
+# set the log, error and output files
+log = mnist_gpu_docker.log.txt
+error = mnist_gpu_docker.err.txt
+output = mnist_gpu_docker.out.txt
+
+# set the executable to run
+executable = mnist_gpu_docker.sh
+arguments = $(Process)
+
+# transfer training data files to the compute node
+transfer_input_files = MNIST_data.tar.gz,src
+
+# transfer the serialized trained model back
+transfer_output_files = mnist_cnn.pt
+
+should_transfer_files = YES
+when_to_transfer_output = ON_EXIT
+
+# We require a machine with a modern version of the CUDA driver
+Requirements = (Target.CUDADriverVersion >= 12.0)
+
+# We must request 1 CPU in addition to 1 GPU
+request_cpus = 1
+request_gpus = 1
+
+# select some memory and disk space
+request_memory = 2GB
+request_disk = 2GB
+
+# Opt in to using CHTC GPU Lab resources
++WantGPULab = true
+# Specify short job type to run more GPUs in parallel
+# Can also request "medium" or "long"
++GPUJobLength = "short"
+
+# Tell HTCondor to run 1 instances of our job:
+queue 1

--- a/episodes/code/mnist-example/htcondor/pixi.toml
+++ b/episodes/code/mnist-example/htcondor/pixi.toml
@@ -1,0 +1,26 @@
+[workspace]
+authors = ["Matthew Feickert <matthew.feickert@cern.ch>"]
+channels = ["conda-forge"]
+name = "htcondor"
+platforms = ["linux-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+python = ">=3.13.5,<3.14"
+
+[feature.cpu.dependencies]
+pytorch-cpu = ">=2.7.0,<3"
+torchvision = ">=0.22.0,<0.23"
+
+[feature.gpu.system-requirements]
+cuda = "12"
+
+[feature.gpu.target.linux-64.dependencies]
+pytorch-gpu = ">=2.7.0,<3"
+torchvision = ">=0.22.0,<0.23"
+
+[environments]
+cpu = ["cpu"]
+gpu = ["gpu"]

--- a/episodes/code/mnist-example/htcondor/src/torch_MNIST.py
+++ b/episodes/code/mnist-example/htcondor/src/torch_MNIST.py
@@ -153,7 +153,7 @@ def main():
     parser.add_argument(
         "--data-dir",
         default=Path.cwd() / "data",
-        help="For Saving the current Model",
+        help="Path to the directory with the MNIST training data (default: current directory/data)",
     )
     args = parser.parse_args()
     args.data_dir = Path(args.data_dir).resolve()
@@ -180,7 +180,9 @@ def main():
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
-    dataset1 = datasets.MNIST(args.data_dir, train=True, download=True, transform=transform)
+    dataset1 = datasets.MNIST(
+        args.data_dir, train=True, download=True, transform=transform
+    )
     dataset2 = datasets.MNIST(args.data_dir, train=False, transform=transform)
     train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)

--- a/episodes/code/mnist-example/htcondor/src/torch_MNIST.py
+++ b/episodes/code/mnist-example/htcondor/src/torch_MNIST.py
@@ -1,0 +1,202 @@
+# https://github.com/pytorch/examples/tree/master/mnist
+from __future__ import print_function
+import argparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.optim.lr_scheduler import StepLR
+from pathlib import Path
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def train(args, model, device, train_loader, optimizer, epoch):
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % args.log_interval == 0:
+            print(
+                "Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}".format(
+                    epoch,
+                    batch_idx * len(data),
+                    len(train_loader.dataset),
+                    100.0 * batch_idx / len(train_loader),
+                    loss.item(),
+                )
+            )
+            if args.dry_run:
+                break
+
+
+def test(model, device, test_loader):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(
+                output, target, reduction="sum"
+            ).item()  # sum up batch loss
+            pred = output.argmax(
+                dim=1, keepdim=True
+            )  # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+
+    print(
+        "\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n".format(
+            test_loss,
+            correct,
+            len(test_loader.dataset),
+            100.0 * correct / len(test_loader.dataset),
+        )
+    )
+
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        metavar="N",
+        help="input batch size for training (default: 64)",
+    )
+    parser.add_argument(
+        "--test-batch-size",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="input batch size for testing (default: 1000)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=14,
+        metavar="N",
+        help="number of epochs to train (default: 14)",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=1.0,
+        metavar="LR",
+        help="learning rate (default: 1.0)",
+    )
+    parser.add_argument(
+        "--gamma",
+        type=float,
+        default=0.7,
+        metavar="M",
+        help="Learning rate step gamma (default: 0.7)",
+    )
+    parser.add_argument(
+        "--no-cuda", action="store_true", default=False, help="disables CUDA training"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="quickly check a single pass",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
+    )
+    parser.add_argument(
+        "--log-interval",
+        type=int,
+        default=10,
+        metavar="N",
+        help="how many batches to wait before logging training status",
+    )
+    parser.add_argument(
+        "--save-model",
+        action="store_true",
+        default=False,
+        help="For Saving the current Model",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=Path.cwd() / "data",
+        help="For Saving the current Model",
+    )
+    args = parser.parse_args()
+    args.data_dir = Path(args.data_dir).resolve()
+    use_cuda = not args.no_cuda and (
+        torch.cuda.is_available() or torch.backends.mps.is_available()
+    )
+
+    torch.manual_seed(args.seed)
+
+    device = "cpu"
+    if use_cuda:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+
+    train_kwargs = {"batch_size": args.batch_size}
+    test_kwargs = {"batch_size": args.test_batch_size}
+    if use_cuda:
+        cuda_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
+        train_kwargs.update(cuda_kwargs)
+        test_kwargs.update(cuda_kwargs)
+
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
+    dataset1 = datasets.MNIST(args.data_dir, train=True, download=True, transform=transform)
+    dataset2 = datasets.MNIST(args.data_dir, train=False, transform=transform)
+    train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
+    test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
+
+    model = Net().to(device)
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, device, train_loader, optimizer, epoch)
+        test(model, device, test_loader)
+        scheduler.step()
+
+    if args.save_model:
+        torch.save(model.state_dict(), "mnist_cnn.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/episodes/code/mnist-example/htcondor/submit.sh
+++ b/episodes/code/mnist-example/htcondor/submit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Download the training data locally to transfer to the worker node
+if [ ! -f "MNIST_data.tar.gz" ]; then
+    # c.f. https://github.com/CHTC/templates-GPUs/blob/450081144c6ae0657123be2a9a357cb432d9d394/shared/pytorch/MNIST_data.tar.gz
+    curl -sLO https://raw.githubusercontent.com/CHTC/templates-GPUs/450081144c6ae0657123be2a9a357cb432d9d394/shared/pytorch/MNIST_data.tar.gz
+fi
+
+# Ensure existing models are backed up
+if [ -f "mnist_cnn.pt" ]; then
+    mv mnist_cnn.pt mnist_cnn_"$(date '+%Y-%m-%d-%H-%M')".pt.bak
+fi
+
+condor_submit mnist_gpu_docker.sub

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -651,6 +651,25 @@ pytorch-gpu  2.7.0    cuda126_mkl_ha999a5f_300        46.1 KiB  conda  https://c
 ```
 
 ```bash
+pixi list cuda
+```
+```output
+Environment: gpu
+Package               Version  Build       Size       Kind   Source
+cuda-crt-tools        12.9.86  ha770c72_1  28.2 KiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-cudart           12.9.79  h5888daf_0  22.7 KiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-cudart_linux-64  12.9.79  h3f2d84a_0  192.6 KiB  conda  https://conda.anaconda.org/conda-forge/
+cuda-cuobjdump        12.9.82  hbd13f7d_0  237.5 KiB  conda  https://conda.anaconda.org/conda-forge/
+cuda-cupti            12.9.79  h9ab20c4_0  1.8 MiB    conda  https://conda.anaconda.org/conda-forge/
+cuda-nvcc-tools       12.9.86  he02047a_1  26.2 MiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-nvdisasm         12.9.88  hbd13f7d_0  5.3 MiB    conda  https://conda.anaconda.org/conda-forge/
+cuda-nvrtc            12.9.86  h5888daf_0  64.1 MiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-nvtx             12.9.79  h5888daf_0  28.6 KiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-nvvm-tools       12.9.86  he02047a_1  23.1 MiB   conda  https://conda.anaconda.org/conda-forge/
+cuda-version          12.9     h4f385c5_3  21.1 KiB   conda  https://conda.anaconda.org/conda-forge/
+```
+
+```bash
 nvidia-smi
 ```
 ```output

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -229,7 +229,48 @@ gpu = ["gpu"]
 :::
 :::
 
-To validate that things are working with the CPU code, let's do a short training run for only 4 epochs in the `cpu` environment.
+To validate that things are working with the CPU code, let's do a short training run for only `2` epochs in the `cpu` environment.
+
+```bash
+pixi run --environment cpu python src/torch_MNIST.py --epochs 2 --save-model --data-dir data
+```
+```output
+100.0%
+100.0%
+100.0%
+100.0%
+Train Epoch: 1 [0/60000 (0%)]	Loss: 2.329474
+Train Epoch: 1 [640/60000 (1%)]	Loss: 1.425185
+Train Epoch: 1 [1280/60000 (2%)]	Loss: 0.826808
+Train Epoch: 1 [1920/60000 (3%)]	Loss: 0.556883
+Train Epoch: 1 [2560/60000 (4%)]	Loss: 0.483756
+...
+Train Epoch: 2 [57600/60000 (96%)]	Loss: 0.146226
+Train Epoch: 2 [58240/60000 (97%)]	Loss: 0.016065
+Train Epoch: 2 [58880/60000 (98%)]	Loss: 0.003342
+Train Epoch: 2 [59520/60000 (99%)]	Loss: 0.001542
+
+Test set: Average loss: 0.0351, Accuracy: 9874/10000 (99%)
+```
+
+::: challenge
+
+## Running multiple ways
+
+What's another way we could have run this other than with `pixi run`?
+
+::: solution
+
+You can enter a shell environment first
+
+```bash
+pixi shell --environment cpu
+python src/torch_MNIST.py --epochs 2 --save-model --data-dir data
+```
+
+:::
+
+:::
 
 ::: keypoints
 

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -17,14 +17,6 @@ exercises: 10
 
 :::
 
-::: callout
-
-## This episode will be on a remote system
-
-All the computation in this episode will take place on a remote system with an HTC workflow manager.
-
-:::
-
 ## High Throughput Computing (HTC)
 
 One of the most common forms of production computing is **high-throughput computing (HTC)**, where computational problems as distributed across multiple computing resources to parallelize computations and reduce total compute time.
@@ -441,6 +433,14 @@ crane ls ghcr.io/<your GitHub username>/pixi-lesson
 ```
 
 ## HTCondor
+
+::: callout
+
+## This episode will be on a remote system
+
+All the computation in the rest of this episode will take place on a remote system with an HTC workflow manager.
+
+:::
 
 To provide a very high level overview of HTCondor in this episode we'll focus on only a few of its many resources and capabilities.
 

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -715,6 +715,13 @@ mfeickert ID: 2127879   6/15 19:13      _      1      _      1 2127879.0
 
 ```
 
+When the job finishes we see that HTCondor has returned to us the following files:
+
+* `mnist_gpu_docker.log.txt`: the HTCondor log file for the job
+* `mnist_gpu_docker.out.txt`: the stdout of all actions executed in the job
+* `mnist_gpu_docker.err.txt`: the stderr of all actions executed in the job
+* `mnist_cnn.pt`: the [serialized trained PyTorch model](https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference)
+
 ::: keypoints
 
 * You can use containerized Pixi environments with HTC systems to be able to run CUDA accelerated code that you defined.

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -1,0 +1,94 @@
+---
+title: "Using Pixi environments on HTC Systems"
+teaching: 40
+exercises: 10
+---
+
+::: questions
+
+* How can you run workflows that use GPUs with Pixi CUDA environments?
+* What solutions exist for the resources you have?
+
+:::
+
+::: objectives
+
+* Learn how to submit containerized workflows to HTC systems.
+
+:::
+
+::: callout
+
+## This episode will be on a remote system
+
+All the computation in this episode will take place on a remote system with an HTC workflow manager.
+
+:::
+
+## High Throughput Computing (HTC)
+
+One of the most common forms of production computing is **high-throughput computing (HTC)**, where computational problems as distributed across multiple computing resources to parallelize computations and reduce total compute time.
+HTC resources are quite dynamic, but usually focus on smaller memory and disk requirements on each individual worker compute node.
+This is in contrast to **high-performance computing (HPC)** where there are comparatively fewer compute nodes but the capabilities and associated memory, disk, and bandwidth resources are much higher.
+
+Two of the most common HTC workflow management systems are [HTCondor](https://htcondor.org/) and [SLURM](https://slurm.schedmd.com/).
+
+## HTCondor
+
+To provide a very high level overview of HTCondor in this episode we'll focus on only a few of its many resources and capabilities.
+
+1. Writing HTCondor execution scripts to define what the HTCondor worker nodes will actually do.
+1. Writing [HTCondor submit description files](https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html) to send our jobs to the HTCondor worker pool.
+1. Submitting those jobs with [`condor_submit`](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html) and monitoring them with [`condor_q`](https://htcondor.readthedocs.io/en/latest/man-pages/condor_q.html).
+
+::: caution
+
+## Connection between execution scripts and submit description files
+
+As HTCondor execution scripts are given as the `executable` field in HTCondor submit description files, they are tightly linked and can not be written fully independently.
+Though they are presented as separate steps above, you will in practice write these together.
+
+:::
+
+Let's first create a new project in our Git repository
+
+```bash
+pixi init ~/pixi-lesson/htcondor
+cd ~/pixi-lesson/htcondor
+```
+```output
+✔ Created ~/<username>/pixi-lesson/htcondor/pixi.toml
+```
+
+### Training a PyTorch model on the MNIST dataset
+
+Let's write a very standard tutorial example of training a deep neral network on the [MNIST dataset](https://en.wikipedia.org/wiki/MNIST_database) with PyTorch and then run it on GPUs in an HTCondor worker pool.
+
+::: caution
+
+## Mea culpa, more interesting examples exist
+
+More exciting examples will be used in the future, but MNIST is perhaps one of the most simple examples to illustrate a point.
+
+:::
+
+#### The neural network code
+
+We'll download Python code that uses a convocational neural network written in PyTorch to learn to identify the handwritten number of the MNIST dataset and place it under a `src/` directory.
+This is a modified example from the PyTorch documentation (https://github.com/pytorch/examples/blob/main/mnist/main.py) which is [licensed under the BSD 3-Clause license](https://github.com/pytorch/examples/blob/abfa4f9cc4379de12f6c340538ef9a697332cccb/LICENSE).
+
+```bash
+curl -sLO https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/a270442b3b910398a25e9a41e26e3c0c93f50e0f/torch_MNIST.py
+mkdir -p src
+mv torch_MNIST.py src/
+```
+
+#### The Pixi environment
+
+Now let's think about what we'd like to do with this code.
+
+::: keypoints
+
+* You can use containerized Pixi environments with HTC systems to be able to run CUDA accelerated code that you defined.
+
+:::

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -57,7 +57,7 @@ We'll download Python code that uses a convocational neural network written in P
 This is a modified example from the PyTorch documentation (https://github.com/pytorch/examples/blob/main/mnist/main.py) which is [licensed under the BSD 3-Clause license](https://github.com/pytorch/examples/blob/abfa4f9cc4379de12f6c340538ef9a697332cccb/LICENSE).
 
 ```bash
-curl -sLO https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/a270442b3b910398a25e9a41e26e3c0c93f50e0f/torch_MNIST.py
+curl -sLO https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/c7889222544928fb6f9fdeb1145767272b5cfec8/torch_MNIST.py
 mkdir -p src
 mv torch_MNIST.py src/
 ```


### PR DESCRIPTION
* Add lesson episode on HTC systems. At the moment, given time limitations, only add information on CHTC and leave SLURM as a TODO.
* Add CI tests for the episodes's Pixi workspace building.
* Add all code and workspace files that are used in the lesson including HTCondor submission files and GitHub Actions workflow definition files.