### PR TITLE
fix: Exclude CentOS7 to ensure pseudoterminal support

### DIFF
--- a/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sub
+++ b/episodes/code/mnist-example/htcondor/mnist_gpu_docker.sub
@@ -27,6 +27,8 @@ when_to_transfer_output = ON_EXIT
 
 # We require a machine with a modern version of the CUDA driver
 Requirements = (Target.CUDADriverVersion >= 12.0)
+# Don't use CentOS7 to ensure pseudoterminal support for interactive jobs
+requirements = (OpSysMajorVer > 7)
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/episodes/htc_systems.md
+++ b/episodes/htc_systems.md
@@ -538,6 +538,8 @@ when_to_transfer_output = ON_EXIT
 
 # We require a machine with a modern version of the CUDA driver
 Requirements = (Target.CUDADriverVersion >= 12.0)
+# Don't use CentOS7 to ensure pseudoterminal support for interactive jobs
+requirements = (OpSysMajorVer > 7)
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1


### PR DESCRIPTION
* Add `requirements = (OpSysMajorVer > 7)` to HTCondor submit description files to ensure that the worker node has a more modern OS than CentOS7 to ensure that interactive jobs will have pseudoterminal support.
* c.f. https://github.com/UW-Madison-DSI/pixi-docker-chtc/pull/21