### PR TITLE
feat: Add additional conda and GPU references

### DIFF
--- a/episodes/conda-pacakges.md
+++ b/episodes/conda-pacakges.md
@@ -610,6 +610,19 @@ Niche particle physics packages:
 :::
 :::
 
+::: checklist
+
+## Further conda package references
+
+[Wolf Vollprecht](https://github.com/wolfv) of prefix.dev GmbH has written blog posts on topics covered in this section that provide an excellent overview and summary.
+You are highly encouraged to read them!
+
+* [What is a Conda package, actually?](https://prefix.dev/blog/what-is-a-conda-package) (2025-06-11)
+* [Virtual Packages in the Conda ecosystem](https://prefix.dev/blog/virtual-packages-in-the-conda-ecosystem) (2025-06-18)
+* [What linking means when installing a Conda package](https://prefix.dev/blog/what-linking-means-when-installing-a-conda-package) (2025-07-17)
+
+:::
+
 ::: keypoints
 
 * Conda packages are specially named `.zip` files that contain files and symbolic links structured in a directory tree.

--- a/episodes/cuda-conda-pacakges.md
+++ b/episodes/cuda-conda-pacakges.md
@@ -654,6 +654,16 @@ we created separate CPU and GPU computational environments that are now fully re
 :::
 :::
 
+::: checklist
+
+## Further CUDA and GPU references
+
+If you would also like a useful summary of different things related to CUDA, check out Modal's summary website of CUDA focused GPU concepts.
+
+* [GPU Glossary](https://modal.com/gpu-glossary), by Modal
+
+:::
+
 ::: keypoints
 
 * The `cuda-version` metapackage can be used to specify constrains on the versions of the `__cuda` virtual package and `cudatoolkit`.


### PR DESCRIPTION
Resolves #24

* Add Wolf Vollprecht's prefix.dev blogs on conda packages.
   - [What is a Conda package, actually?](https://prefix.dev/blog/what-is-a-conda-package) (2025-06-11)
   - [Virtual Packages in the Conda ecosystem](https://prefix.dev/blog/virtual-packages-in-the-conda-ecosystem) (2025-06-18)
   - [What linking means when installing a Conda package](https://prefix.dev/blog/what-linking-means-when-installing-a-conda-package) (2025-07-17)

* Add Modal's GPU Glossary page.
   - c.f. https://modal.com/gpu-glossary