### PR TITLE
feat: Update and correct Linux containers episode

### DIFF
--- a/episodes/code/.github/workflows/apptainer.yaml
+++ b/episodes/code/.github/workflows/apptainer.yaml
@@ -1,0 +1,73 @@
+name: Apptainer Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+    paths:
+      - 'cuda-exercise/pixi.toml'
+      - 'cuda-exercise/pixi.lock'
+      - 'cuda-exercise/apptainer.def'
+      - 'cuda-exercise/app/**'
+  pull_request:
+    paths:
+      - 'cuda-exercise/pixi.toml'
+      - 'cuda-exercise/pixi.lock'
+      - 'cuda-exercise/apptainer.def'
+      - 'cuda-exercise/app/**'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  docker:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Free disk space
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+
+      - name: Build container from definition file
+        working-directory: ./cuda-exercise
+        run: apptainer build gpu-noble-cuda-12.9.sif apptainer.def
+
+      - name: Test container
+        working-directory: ./cuda-exercise
+        run: apptainer test gpu-noble-cuda-12.9.sif
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy built container
+        if: github.event_name != 'pull_request'
+        working-directory: ./cuda-exercise
+        run: apptainer push gpu-noble-cuda-12.9.sif oras://ghcr.io/${{ github.repository }}:gpu-noble-cuda-12.9-apptainer

--- a/episodes/code/.github/workflows/docker.yaml
+++ b/episodes/code/.github/workflows/docker.yaml
@@ -1,0 +1,91 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+    paths:
+      - 'cuda-exercise/pixi.toml'
+      - 'cuda-exercise/pixi.lock'
+      - 'cuda-exercise/Dockerfile'
+      - 'cuda-exercise/.dockerignore'
+      - 'cuda-exercise/app/**'
+  pull_request:
+    paths:
+      - 'cuda-exercise/pixi.toml'
+      - 'cuda-exercise/pixi.lock'
+      - 'cuda-exercise/Dockerfile'
+      - 'cuda-exercise/.dockerignore'
+      - 'cuda-exercise/app/**'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  docker:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=gpu-noble-cuda-12.9
+            type=raw,value=latest
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test build
+        id: docker_build_test
+        uses: docker/build-push-action@v6
+        with:
+          context: cuda-exercise
+          file: cuda-exercise/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          pull: true
+
+      - name: Deploy build
+        id: docker_build_deploy
+        uses: docker/build-push-action@v6
+        with:
+          context: cuda-exercise
+          file: cuda-exercise/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}

--- a/episodes/code/cuda-exercise/Dockerfile
+++ b/episodes/code/cuda-exercise/Dockerfile
@@ -1,17 +1,27 @@
+# Declare build ARGs in global scope
+ARG CUDA_VERSION="12"
+ARG ENVIRONMENT="gpu"
+
 FROM ghcr.io/prefix-dev/pixi:noble AS build
+
+# Redeclaring ARGs in a stage without a value inherits the global default
+ARG CUDA_VERSION
+ARG ENVIRONMENT
 
 WORKDIR /app
 COPY . .
-ENV CONDA_OVERRIDE_CUDA=12
-RUN pixi install --locked --environment gpu
+ENV CONDA_OVERRIDE_CUDA=$CUDA_VERSION
+RUN pixi install --locked --environment $ENVIRONMENT
 RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
-    pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
+    pixi shell-hook --environment $ENVIRONMENT -s bash >> /app/entrypoint.sh && \
     echo 'exec "$@"' >> /app/entrypoint.sh
 
-FROM ghcr.io/prefix-dev/pixi:noble AS production
+FROM ghcr.io/prefix-dev/pixi:noble AS final
+
+ARG ENVIRONMENT
 
 WORKDIR /app
-COPY --from=build /app/.pixi/envs/gpu /app/.pixi/envs/gpu
+COPY --from=build /app/.pixi/envs/$ENVIRONMENT /app/.pixi/envs/$ENVIRONMENT
 COPY --from=build /app/pixi.toml /app/pixi.toml
 COPY --from=build /app/pixi.lock /app/pixi.lock
 # The ignore files are needed for 'pixi run' to work in the container
@@ -19,7 +29,8 @@ COPY --from=build /app/.pixi/.gitignore /app/.pixi/.gitignore
 COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
 COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
 
+# This bit is needed only if you have code you _want_ to deploy in the container.
+# This is rare as you normally want your code to be able to get brought into a container later.
 COPY ./app /app/src
 
-EXPOSE 8000
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/episodes/code/cuda-exercise/apptainer.def
+++ b/episodes/code/cuda-exercise/apptainer.def
@@ -12,9 +12,9 @@ Stage: build
 export CONDA_OVERRIDE_CUDA=12
 cd /app/
 pixi info
-pixi install --locked --environment prod
+pixi install --locked --environment gpu
 echo "#!/bin/bash" > /app/entrypoint.sh && \
-pixi shell-hook --environment prod -s bash >> /app/entrypoint.sh && \
+pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
 echo 'exec "$@"' >> /app/entrypoint.sh
 
 
@@ -23,7 +23,7 @@ From: ghcr.io/prefix-dev/pixi:noble
 Stage: final
 
 %files from build
-/app/.pixi/envs/prod /app/.pixi/envs/prod
+/app/.pixi/envs/gpu /app/.pixi/envs/gpu
 /app/pixi.toml /app/pixi.toml
 /app/pixi.lock /app/pixi.lock
 /app/.gitignore /app/.gitignore

--- a/episodes/cuda-conda-pacakges.md
+++ b/episodes/cuda-conda-pacakges.md
@@ -668,6 +668,28 @@ we created separate CPU and GPU computational environments that are now fully re
 :::
 :::
 
+
+::: callout
+
+## Version Control
+
+On a **new branch** in your repository, add and commit the files from this episode.
+
+```bash
+git add cuda-example/pixi.* cuda-example/git.*
+git add cuda-exercise/pixi.* cuda-exercise/git.*
+```
+
+Then push your branch to your remote on GitHub
+
+```bash
+git push -u origin HEAD
+```
+
+and make a pull request to merge your changes into your remote's default branch.
+
+:::
+
 ::: checklist
 
 ## Further CUDA and GPU references

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -83,10 +83,11 @@ Luckily, to install Pixi environments into Docker container images there is **ef
 
 ## Moving files
 
-To use it later, move `torch_detect_GPU.py` from the end of the CUDA conda packages episode to `./app/torch_detect_GPU.py`.
+To use it later, we'll place the `torch_detect_GPU.py` code from the end of the CUDA conda packages episode at `./app/torch_detect_GPU.py`.
 
 ```bash
-mv torch_detect_GPU.py app/
+mkdir -p app
+curl -sL https://github.com/matthewfeickert/nvidia-gpu-ml-library-test/raw/36c725360b1b1db648d6955c27bd3885b29a3273/torch_detect_GPU.py -o /app/torch_detect_GPU.py
 ```
 
 :::
@@ -122,6 +123,10 @@ COPY --from=build /app/pixi.lock /app/pixi.lock
 COPY --from=build /app/.pixi/.gitignore /app/.pixi/.gitignore
 COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
 COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
+
+# This bit is needed only if you have code you _want_ to deploy in the container.
+# This is rare as you normally want your code to be able to get brought into a container later.
+COPY ./app /app/src
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 ```

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -329,6 +329,30 @@ jobs:
 
 This will build your Dockerfile in GitHub Actions CI into a [`linux/amd64` platform](https://docs.docker.com/build/building/multi-platform/) Docker container image and then deploy it to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr`) associated with your repository.
 
+::: callout
+
+## Version Control
+
+We now want to use these tools to build our Pixi environment into a Linux container.
+
+On a **new branch** in your repository, add and commit the files from this episode.
+
+```bash
+git add cuda-exercise/app
+git add cuda-exercise/Dockerfile
+git add .github
+```
+
+Then push your branch to your remote on GitHub
+
+```bash
+git push -u origin HEAD
+```
+
+and make a pull request to merge your changes into your remote's default branch.
+
+:::
+
 ## Building Apptainer containers with Pixi environments
 
 Most HTC and HPC systems do not allow users to use Docker given security risks and instead use Apptainer.

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -225,7 +225,7 @@ With this `Dockerfile` the container image can then be built with [`docker build
 
 ### Automation with GitHub Actions workflows
 
-In the personal GitHub repository that we've been working in create a GitHub Actions workflow directory
+In the personal GitHub repository that we've been working in, create a GitHub Actions workflow directory from the top level of the repository
 
 ```bash
 mkdir -p .github/workflows

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -287,7 +287,7 @@ jobs:
             ghcr.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=noble-cuda-12.9
+            type=raw,value=gpu-noble-cuda-12.9
             type=raw,value=latest
             type=sha
 
@@ -360,7 +360,7 @@ In most situations, Apptainer is able to automatically convert a Docker image, o
 However, the overlay system of Apptainer is different from Docker, which means that the `ENTRYPOINT` of a Docker container image might not get correctly translated into an Apptainer `runscript` and `startscript`.
 In might be advantageous, depending on your situation, to instead write an [Apptainer `.def` definition file](https://apptainer.org/docs/user/main/definition_files.html), giving full control over the commands, and then build that `.def` file into an `.sif` Apptainer container image.
 
-We can build a very similar Apptainer container image definition file to the Dockerfile we wrote
+We can build a very similar `apptainer.def` Apptainer container image definition file to the Dockerfile we wrote
 
 ```
 Bootstrap: docker
@@ -597,12 +597,12 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2
 
       - name: Build container from definition file
-        working-directory: ./examples/hello_pytorch
-        run: apptainer build pixi-docker-chtc.sif apptainer.def
+        working-directory: ./cuda-exercise
+        run: apptainer build gpu-noble-cuda-12.9.sif apptainer.def
 
       - name: Test container
-        working-directory: ./examples/hello_pytorch
-        run: apptainer test pixi-docker-chtc.sif
+        working-directory: ./cuda-exercise
+        run: apptainer test gpu-noble-cuda-12.9.sif
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -614,8 +614,8 @@ jobs:
 
       - name: Deploy built container
         if: github.event_name != 'pull_request'
-        working-directory: ./examples/hello_pytorch
-        run: apptainer push pixi-docker-chtc.sif oras://ghcr.io/${{ github.repository }}:hello-pytorch-noble-cuda-12.9-apptainer
+        working-directory: ./cuda-exercise
+        run: apptainer push gpu-noble-cuda-12.9.sif oras://ghcr.io/${{ github.repository }}:gpu-noble-cuda-12.9-apptainer
 ```
 
 This will build your Apptainer definition file in GitHub Actions CI into a `.sif` container image and then deploy it to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr`) associated with your repository.

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -377,9 +377,9 @@ Stage: build
 export CONDA_OVERRIDE_CUDA=12
 cd /app/
 pixi info
-pixi install --locked --environment prod
+pixi install --locked --environment gpu
 echo "#!/bin/bash" > /app/entrypoint.sh && \
-pixi shell-hook --environment prod -s bash >> /app/entrypoint.sh && \
+pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
 echo 'exec "$@"' >> /app/entrypoint.sh
 
 
@@ -388,7 +388,7 @@ From: ghcr.io/prefix-dev/pixi:noble
 Stage: final
 
 %files from build
-/app/.pixi/envs/prod /app/.pixi/envs/prod
+/app/.pixi/envs/gpu /app/.pixi/envs/gpu
 /app/pixi.toml /app/pixi.toml
 /app/pixi.lock /app/pixi.lock
 /app/.gitignore /app/.gitignore
@@ -455,9 +455,9 @@ export CONDA_OVERRIDE_CUDA=12
 ...
 cd /app/
 pixi info
-pixi install --locked --environment prod
+pixi install --locked --environment gpu
 echo "#!/bin/bash" > /app/entrypoint.sh && \
-pixi shell-hook --environment prod -s bash >> /app/entrypoint.sh && \
+pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
 echo 'exec "$@"' >> /app/entrypoint.sh
 ```
 
@@ -470,7 +470,7 @@ From: ghcr.io/prefix-dev/pixi:noble
 Stage: final
 
 %files from build
-/app/.pixi/envs/prod /app/.pixi/envs/prod
+/app/.pixi/envs/gpu /app/.pixi/envs/gpu
 /app/pixi.toml /app/pixi.toml
 /app/pixi.lock /app/pixi.lock
 /app/.gitignore /app/.gitignore

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -92,29 +92,37 @@ mv torch_detect_GPU.py app/
 :::
 
 ```dockerfile
+# Declare build ARGS in global scope
+ARG CUDA_VERSION="12"
+ARG ENVIRONMENT="gpu"
+
 FROM ghcr.io/prefix-dev/pixi:noble AS build
+
+# Redeclaring ARGS in a stage without a value inherits the global default
+ARG CUDA_VERSION
+ARG ENVIRONMENT
 
 WORKDIR /app
 COPY . .
-ENV CONDA_OVERRIDE_CUDA=<cuda version>
-RUN pixi install --locked --environment <environment>
+ENV CONDA_OVERRIDE_CUDA=$CUDA_VERSION
+RUN pixi install --locked --environment $ENVIRONMENT
 RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
-    pixi shell-hook --environment <environment> -s bash >> /app/entrypoint.sh && \
+    pixi shell-hook --environment $ENVIRONMENT -s bash >> /app/entrypoint.sh && \
     echo 'exec "$@"' >> /app/entrypoint.sh
 
-FROM ghcr.io/prefix-dev/pixi:noble AS production
+FROM ghcr.io/prefix-dev/pixi:noble AS final
+
+ARG ENVIRONMENT
 
 WORKDIR /app
-COPY --from=build /app/.pixi/envs/<environment> /app/.pixi/envs/<environment>
+COPY --from=build /app/.pixi/envs/$ENVIRONMENT /app/.pixi/envs/$ENVIRONMENT
 COPY --from=build /app/pixi.toml /app/pixi.toml
 COPY --from=build /app/pixi.lock /app/pixi.lock
 # The ignore files are needed for 'pixi run' to work in the container
 COPY --from=build /app/.pixi/.gitignore /app/.pixi/.gitignore
 COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
 COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
-COPY ./app /app/src
 
-EXPOSE <PORT>
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 ```
 

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -87,7 +87,7 @@ To use it later, we'll place the `torch_detect_GPU.py` code from the end of the 
 
 ```bash
 mkdir -p app
-curl -sL https://github.com/matthewfeickert/nvidia-gpu-ml-library-test/raw/36c725360b1b1db648d6955c27bd3885b29a3273/torch_detect_GPU.py -o /app/torch_detect_GPU.py
+curl -sL https://github.com/matthewfeickert/nvidia-gpu-ml-library-test/raw/36c725360b1b1db648d6955c27bd3885b29a3273/torch_detect_GPU.py -o ./app/torch_detect_GPU.py
 ```
 
 :::

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -534,7 +534,7 @@ apptainer build <container image name>.sif <definition file name>.def
 
 ### Automation with GitHub Actions workflows
 
-In the personal GitHub repository that we've been working in create a GitHub Actions workflow directory
+In the personal GitHub repository that we've been working in, create a GitHub Actions workflow directory from the top level of the repository
 
 ```bash
 mkdir -p .github/workflows
@@ -619,6 +619,29 @@ jobs:
 ```
 
 This will build your Apptainer definition file in GitHub Actions CI into a `.sif` container image and then deploy it to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr`) associated with your repository.
+
+::: callout
+
+## Version Control
+
+We now want to use these tools to build our Pixi environment into a Linux container.
+
+On a **new branch** in your repository, add and commit the files from this episode.
+
+```bash
+git add cuda-exercise/apptainer.def
+git add .github/workflows/apptainer.yaml
+```
+
+Then push your branch to your remote on GitHub
+
+```bash
+git push -u origin HEAD
+```
+
+and make a pull request to merge your changes into your remote's default branch.
+
+:::
 
 ::: keypoints
 

--- a/episodes/pixi-deployment.md
+++ b/episodes/pixi-deployment.md
@@ -333,7 +333,7 @@ This will build your Dockerfile in GitHub Actions CI into a [`linux/amd64` platf
 
 ## Version Control
 
-We now want to use these tools to build our Pixi environment into a Linux container.
+We now want to use these tools to build our Pixi environment into a Docker Linux container.
 
 On a **new branch** in your repository, add and commit the files from this episode.
 
@@ -624,7 +624,7 @@ This will build your Apptainer definition file in GitHub Actions CI into a `.sif
 
 ## Version Control
 
-We now want to use these tools to build our Pixi environment into a Linux container.
+We now want to use these tools to build our Pixi environment into an Apptainer Linux container.
 
 On a **new branch** in your repository, add and commit the files from this episode.
 


### PR DESCRIPTION
* Use Dockerfile `ARG` variables to make the `CONDA_OVERRIDE_CUDA` and environment names variables
  that can be set at the command line. Use global and local scope to only declare ARG values once.
  This results in the Dockerfile now being a template.
   - c.f. https://docs.docker.com/reference/dockerfile/#arg 
   - c.f. https://docs.docker.com/build/building/variables/#scoping
* Rename 'prod' environment to 'gpu' for clarity.
* Remove PORTS as not clearly needed.
* Update Dockerfile walkthrough.
* Add version control callouts.
* Use 'gpu' tags for clarity.
* Correct Apptainer GitHub Actions workflow file to use the correct working directory.
   - This was a copy error from https://github.com/UW-Madison-DSI/pixi-docker-chtc
* Add GitHub Actions workflow files as code example files for the repository.